### PR TITLE
Błąd gdzie odliczanie pokazuje time zamiast liczb

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,4 +19,5 @@ const countdown = () => {
   document.querySelector(".second").innerText = textSecond;
 };
 
+countdown();
 setInterval(countdown, 1000);


### PR DESCRIPTION
Dokładnie to co w tytule

Kroki reprodukcji błędu:
1. Odśwież stronę

Robie pull requesta tylko dla tego, że to jest taki major bug z którym dożynki nie smakują tak samo
Pozdrawiam